### PR TITLE
feat: トップページ実装の復元

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,34 @@
-<h1>トップページ</h1>
+<div class="min-h-screen flex items-center justify-center bg-gray-50">
+  <div class="w-full max-w-md p-8 space-y-8 text-center">
+    <% if user_signed_in? %>
+      <h1 class="text-2xl font-bold text-gray-900">こんにちは、<%= current_user.email %>さん！</h1>
+      <div class="space-y-4">
+        <a href="#" class="flex items-center justify-center w-full px-4 py-3 text-white bg-[#278B5B] rounded-md hover:bg-opacity-90">
+          <i class="fas fa-list-ul mr-2"></i>
+          <span>カテゴリー一覧</span>
+        </a>
+        <a href="#" class="flex items-center justify-center w-full px-4 py-3 text-white bg-[#278B5B] rounded-md hover:bg-opacity-90">
+          <i class="fas fa-pencil-alt mr-2"></i>
+          <span>クイズで練習</span>
+        </a>
+        <a href="#" class="flex items-center justify-center w-full px-4 py-3 text-white bg-[#278B5B] rounded-md hover:bg-opacity-90">
+          <i class="fas fa-search mr-2"></i>
+          <span>質問をキーワードで検索</span>
+        </a>
+        <a href="#" class="flex items-center justify-center w-full px-4 py-3 text-white bg-[#278B5B] rounded-md hover:bg-opacity-90">
+          <i class="fas fa-star mr-2"></i>
+          <span>お気に入りした質問一覧</span>
+        </a>
+      </div>
+    <% else %>
+      <div class="space-y-6">
+        <h1 class="text-3xl font-bold text-gray-900">初めての英語対応、もう怖くない。</h1>
+        <p class="text-gray-600">短時間で聞かれる質問と答えを今ここで準備しよう！</p>
+        <div class="space-y-4">
+          <%= link_to "ログイン", new_user_session_path, class: "block w-full px-4 py-3 text-white bg-[#278B5B] rounded-md hover:bg-opacity-90" %>
+          <%= link_to "アカウントを作成", new_user_registration_path, class: "block w-full px-4 py-3 text-white bg-[#278B5B] rounded-md hover:bg-opacity-90" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
@@ -19,12 +20,12 @@
           </div>
           <nav class="hidden md:flex items-center space-x-4">
             <%= link_to "ホーム", root_path, class: "text-gray-600 hover:text-gray-800" %>
-            <%= link_to "クイズを始める", "#", class: "text-gray-600 hover:text-gray-800" %>
+            <%= link_to "クイズで練習", "#", class: "text-gray-600 hover:text-gray-800" %>
             <% if user_signed_in? %>
               <%= link_to "マイページ", "#", class: "text-gray-600 hover:text-gray-800" %>
               <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded" %>
             <% else %>
-              <%= link_to "新規登録", new_user_registration_path, class: "text-gray-600 hover:text-gray-800" %>
+              <%= link_to "アカウントを作成", new_user_registration_path, class: "text-gray-600 hover:text-gray-800" %>
               <%= link_to "ログイン", new_user_session_path, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
             <% end %>
           </nav>


### PR DESCRIPTION
### ✅ トップページ実装の復元

#### 概要
Revert "Merge pull request #61 from rikiya-0331/feat/29-top-page" #62というコミットを行ったことによって、`main`ブランチから失われたトップページの実装を復元します。

#### 目的
- アプリケーションのルートパスでトップページが正常に表示されるようにする。
- ログイン状態に応じて、ナビゲーションやコンテンツが正しく切り替わるようにする。

#### 実装内容
- `app/views/home/index.html.erb`に、ログイン状態に応じたトップページのデザインを再実装しました。
- `config/routes.rb`に`root "home#index"`のルーティングが設定されていることを確認しました。

#### 変更前と変更後
**変更前**
- ルートパスにアクセスしてもトップページがなく、または意図しない表示になっていました。

**変更後**
- ルートパスで正しくトップページが表示され、ログイン状態に応じてコンテンツが切り替わります。

#### 動作確認方法
1. ブラウザで`http://localhost:3000`にアクセスし、トップページが正常に表示されることを確認する。
2. 未ログイン時に「ログインする」ボタンが表示されていることを確認する。
3. ログイン済みの状態で、ユーザー名と各機能へのボタンが表示されることを確認する。