### PR TITLE
feat: カテゴリと質問モデルの追加

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  has_many :questions
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,3 @@
+class Question < ApplicationRecord
+  belongs_to :category
+end

--- a/db/migrate/20250811021124_create_categories.rb
+++ b/db/migrate/20250811021124_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250811021136_create_questions.rb
+++ b/db/migrate/20250811021136_create_questions.rb
@@ -1,0 +1,13 @@
+class CreateQuestions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :questions do |t|
+      t.text :title_jp
+      t.text :title_en
+      t.text :answer_jp
+      t.text :answer_en
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_05_131048) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_11_021136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "questions", force: :cascade do |t|
+    t.text "title_jp"
+    t.text "title_en"
+    t.text "answer_jp"
+    t.text "answer_en"
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_questions_on_category_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -32,4 +49,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_05_131048) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "questions", "categories"
 end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title_jp: MyText
+  title_en: MyText
+  answer_jp: MyText
+  answer_en: MyText
+  category: one
+
+two:
+  title_jp: MyText
+  title_en: MyText
+  answer_jp: MyText
+  answer_en: MyText
+  category: two

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class QuestionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Closes #51

### ✅ カテゴリと質問モデルの追加

#### 概要
クイズアプリケーションの主要なデータ構造である、カテゴリと質問のデータベーステーブルとRailsモデルを定義しました。これにより、質問とカテゴリの基本的な管理が可能になります。

#### 目的
- クイズのカテゴリ情報をデータベースに保存できるようにする。
- クイズの質問（日本語・英語）とその解答（日本語・英語）を正確に保存・管理できるようにする。
- 各質問を適切なカテゴリに分類できるようにする。

#### 実装内容
- `docker-compose exec web rails g model Category name:string` を実行し、`categories` テーブルと `Category` モデルを作成しました。
- `docker-compose exec web rails g model Question title_jp:text title_en:text answer_jp:text answer_en:text category:references` を実行し、`questions` テーブルと `Question` モデルを作成しました。
- モデル間に `has_many` と `belongs_to` の関連付けを設定しました。
- `docker-compose exec web rails db:migrate` を実行し、データベースにテーブルが作成されることを確認しました。

#### 変更前と変更後
**変更前**
- カテゴリや質問を保存するためのデータベーステーブルが存在しませんでした。
- 対応するRailsモデルも定義されていませんでした。

**変更後**
- `categories` と `questions` テーブルがデータベースに作成されました。
- `Category` と `Question` モデルが定義され、相互に関連付けられました。
- モデルの作成、読み込み、関連付けがRailsコンソールで正しく機能することを確認しました。

#### 動作確認方法
1. `docker-compose up`でサーバーを起動します。
2. ターミナルで`docker-compose exec web rails c`を実行して、Railsコンソールを起動します。
3. プロンプト（`irb(main):001:0>`）が表示されたら、以下のコードを1行ずつ実行します。
    ```ruby
    c = Category.create(name: 'Greetings')
    q = Question.create(title_jp: 'こんにちは', title_en: 'Hello', answer_jp: 'こんにちは', answer_en: 'Hello', category: c)
    puts "Category has #{c.questions.count} question(s)."
    puts "Question's category is '#{q.category.name}'."
    ```
4. 以下の出力がされることを確認します。
    * `Category has 1 question(s).`
    * `Question's category is 'Greetings'.`
5. 確認が完了したら、`exit`と入力してコンソールを終了します。
6. Renderへのデプロイが成功したことを確認。