### PR TITLE
feat: 質問一覧ページの基本構造を作成

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,6 @@
+class QuestionsController < ApplicationController
+  def index
+    @categories = Category.all
+    @questions = Question.all.includes(:category)
+  end
+end

--- a/app/javascript/controllers/filter_controller.js
+++ b/app/javascript/controllers/filter_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="filter"
+export default class extends Controller {
+  static targets = ["item"]
+
+  filter(event) {
+    const categoryId = event.currentTarget.dataset.categoryId
+
+    this.itemTargets.forEach(item => {
+      if (categoryId === 'all' || item.dataset.categoryId === categoryId) {
+        item.style.display = 'block'
+      } else {
+        item.style.display = 'none'
+      }
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,11 @@
 
 import { application } from "./application"
 
+import FilterController from "./filter_controller"
+application.register("filter", FilterController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import QaCardController from "./qa_card_controller"
+application.register("qa-card", QaCardController)

--- a/app/javascript/controllers/qa_card_controller.js
+++ b/app/javascript/controllers/qa_card_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="qa-card"
+export default class extends Controller {
+  static targets = ["japanese", "button"]
+
+  toggle() {
+    this.japaneseTarget.classList.toggle("hidden")
+
+    const isHidden = this.japaneseTarget.classList.contains("hidden")
+    this.buttonTarget.textContent = isHidden ? "日本語訳を見る" : "日本語訳を隠す"
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,7 @@
           <nav class="hidden md:flex items-center space-x-4">
             <%= link_to "ホーム", root_path, class: "text-gray-600 hover:text-gray-800" %>
             <%= link_to "クイズで練習", "#", class: "text-gray-600 hover:text-gray-800" %>
+            <%= link_to "質問一覧", questions_path, class: "text-gray-600 hover:text-gray-800" %>
             <% if user_signed_in? %>
               <%= link_to "マイページ", "#", class: "text-gray-600 hover:text-gray-800" %>
               <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded" %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,0 +1,25 @@
+<div class="container mx-auto px-4 py-8" data-controller="filter">
+  <h1 class="text-3xl font-bold mb-6 text-center">質問一覧</h1>
+
+  <div class="flex flex-wrap justify-center gap-2 mb-8">
+    <button data-action="click->filter#filter" data-category-id="all" class="bg-blue-500 text-white font-bold py-2 px-4 rounded-full hover:bg-blue-700 transition duration-300">全て表示</button>
+    <% @categories.each do |category| %>
+      <button data-action="click->filter#filter" data-category-id="<%= category.id %>" class="bg-gray-200 text-gray-800 font-bold py-2 px-4 rounded-full hover:bg-gray-300 transition duration-300">
+        <%= category.name %>
+      </button>
+    <% end %>
+  </div>
+
+  <div id="questions-list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <% @questions.each do |question| %>
+      <div data-filter-target="item" data-category-id="<%= question.category_id %>" class="bg-white rounded-lg shadow-md p-6" data-controller="qa-card">
+        <span class="inline-block bg-blue-100 text-blue-800 text-xs font-semibold mb-2 px-2.5 py-0.5 rounded-full"><%= question.category.name %></span>
+        <h2 class="text-xl font-bold mb-2"><%= question.title_en %></h2>
+        <button data-action="click->qa-card#toggle" data-qa-card-target="button" class="bg-gray-500 text-white font-bold py-2 px-4 rounded mt-2 hover:bg-gray-600 transition duration-300">
+          日本語訳を見る
+        </button>
+        <p class="text-lg mt-4 hidden" data-qa-card-target="japanese"><%= question.title_jp %></p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "home#index"
+
+  resources :questions, only: [:index]
 end


### PR DESCRIPTION
Closes #18

### ✅ 概要
クイズアプリケーションのコア機能である、質問の一覧表示機能とカテゴリ別フィルター機能を実装しました。ユーザーは特定のカテゴリの質問に絞り込んだり、すべての質問を一覧で閲覧したりできます。

### 目的
ユーザーが興味のあるカテゴリの質問に素早くアクセスできるようにするため。

### 実装内容
この実装は、大きく分けて**3つの段階**で進めました。

1.  **質問一覧ページの基本構造**:
    - `questions#index`へのルーティングを`config/routes.rb`に追加しました。
    - `QuestionsController`に`index`アクションを定義し、全カテゴリと全質問をビューに渡すようにしました。
    - `app/views/questions/index.html.erb`に、質問リストの基本的なHTML構造を定義しました。

2.  **カテゴリ絞り込み機能**:
    - `app/javascript/controllers/filter_controller.js`を作成し、Stimulusでフィルターロジックを実装しました。
    - ビュー内のカテゴリボタンと質問カードに、`data-controller`, `data-action`, `data-target`などの属性を適切に設定し、JavaScriptとHTMLを連携させました。

3.  **日本語/英語表示切り替え機能**:
    - `app/javascript/controllers/qa_card_controller.js`を作成し、質問カード内のボタンクリックで日本語訳を表示・非表示にするロジックを実装しました。
    - `app/javascript/controllers/index.js`に新しいコントローラを登録し、`./bin/rails stimulus:manifest:update`を実行してマニフェストを更新しました。

### 変更前と変更後
**変更前**
- 質問一覧ページが存在せず、ユーザーは質問を閲覧できませんでした。
- 関連モデル（`Category`, `Question`）は存在しましたが、ビューでの表示やフィルター機能は未実装でした。

**変更後**
- `/questions`にアクセスすることで、全ての質問を一覧で表示できるようになりました。
- カテゴリボタンをクリックすることで、質問を動的に絞り込むことが可能です。
- 質問の日本語訳をボタンで表示・非表示に切り替えられます。

### 動作確認方法
**1. サーバーを起動**
`docker compose up`でアプリケーションを起動します。

**2. ページの確認**
ブラウザで `http://localhost:3000/questions` にアクセスします。

**3. 機能の検証**
- ページ上部のカテゴリボタンをクリックし、表示される質問が正しく絞り込まれることを確認。
- 「全て表示」ボタンをクリックし、すべての質問が再表示されることを確認。
- 各質問カード内の「日本語訳を見る」ボタンをクリックし、テキストが切り替わることを確認。
- ブラウザのウィンドウサイズを変更し、レイアウトがレスポンシブに対応していることを確認。