### PR TITLE
feat: クイズ履歴詳細表示機能を追加

### DIFF
--- a/app/controllers/quiz_histories_controller.rb
+++ b/app/controllers/quiz_histories_controller.rb
@@ -1,0 +1,7 @@
+class QuizHistoriesController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @quiz_history = current_user.quiz_histories.includes(quiz_results: [{ question: :answer_choices }, :selected_answer_choice]).find(params[:id])
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,4 +4,8 @@ class Question < ApplicationRecord
   has_many :quiz_results, dependent: :destroy
 
   accepts_nested_attributes_for :answer_choices
+
+  def correct_answer
+    answer_choices.find_by(is_correct: true)
+  end
 end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -12,6 +12,7 @@
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">実施日時</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">正答率</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">スコア</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"></th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200">
@@ -21,6 +22,9 @@
               <td class="px-6 py-4 whitespace-nowrap"><%= l(quiz_history.created_at, format: :long) %></td>
               <td class="px-6 py-4 whitespace-nowrap"><%= quiz_history.correct_answers %> / <%= quiz_history.total_questions %></td>
               <td class="px-6 py-4 whitespace-nowrap"><%= quiz_history.score %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <%= link_to '詳細', quiz_history_path(quiz_history), class: 'text-blue-600 hover:text-blue-900' %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/quiz_histories/show.html.erb
+++ b/app/views/quiz_histories/show.html.erb
@@ -1,0 +1,55 @@
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-6">クイズ結果詳細</h1>
+
+  <div class="bg-white shadow-md rounded-lg p-6 mb-8">
+    <h2 class="text-xl font-semibold mb-4">概要</h2>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div>
+        <p class="text-gray-600">カテゴリ</p>
+        <p class="font-semibold"><%= @quiz_history.category.name %></p>
+      </div>
+      <div>
+        <p class="text-gray-600">実施日時</p>
+        <p class="font-semibold"><%= l(@quiz_history.created_at, format: :long) %></p>
+      </div>
+      <div>
+        <p class="text-gray-600">スコア</p>
+        <p class="font-semibold"><%= @quiz_history.score %></p>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="text-xl font-semibold mb-4">問題ごとの結果</h2>
+
+  <div class="space-y-6">
+    <% @quiz_history.quiz_results.each_with_index do |result, index| %>
+      <div class="bg-white shadow-md rounded-lg p-6">
+        <h3 class="text-lg font-semibold mb-4">問題 <%= index + 1 %></h3>
+        <p class="mb-4 bg-gray-50 p-4 rounded"><%= result.question.title_en %></p>
+
+        <% is_correct = result.selected_answer_choice&.is_correct? %>
+
+        <div class="mb-4">
+          <p class="font-semibold">あなたの回答:</p>
+          <div class="flex items-center space-x-2 mt-2">
+            <% if is_correct %>
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-green-100 text-green-800">正解</span>
+            <% else %>
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-red-100 text-red-800">不正解</span>
+            <% end %>
+            <p class="text-gray-800"><%= result.selected_answer_choice&.content_jp || '未回答' %></p>
+          </div>
+        </div>
+
+        <div>
+          <p class="font-semibold">正解:</p>
+          <p class="text-gray-800 mt-2"><%= result.question.correct_answer.content_jp %></p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-8">
+    <%= link_to 'マイページに戻る', mypage_path, class: "text-blue-500 hover:text-blue-700" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resource :mypage, only: [:show]
+  resources :quiz_histories, only: [:show]
   resources :quizzes, path: 'quiz', only: [:show] do
     collection do
       get :start


### PR DESCRIPTION
Closes #43

### 概要
マイページに表示されている各クイズ履歴をクリックすると、そのクイズで出題された個々の質問と、それに対するユーザーの回答、正誤判定を詳細に確認できるページを実装しました。これにより、ユーザーは過去のクイズ内容を振り返り、復習することが可能になります。

### 完了の定義
- 各クイズ履歴から詳細ページへ遷移できること。
- 詳細ページでクイズの概要情報（カテゴリ、実施日時、スコアなど）が正しく表示されること。
- 各問題について、質問内容、ユーザーの回答、正しい回答、正誤判定が一覧表示されること。
- ログインユーザーが、他のユーザーのクイズ履歴詳細ページに直接アクセスできないこと。

### 実装内容
* **ルーティングとコントローラーの追加**:
    * `QuizHistoriesController`を作成し、`show`アクションを実装しました。
    * `config/routes.rb`に`resources :quiz_histories, only: [:show]`を追加し、ルーティングを設定しました。
* **データ取得と権限チェック**:
    * `show`アクション内で、URLから渡された`id`を用いて`QuizHistory`レコードを取得し、`current_user`が所有しているか確認する権限チェックを追加しました。
    * N+1問題を防ぐため、`includes`メソッドを使用して、関連する`QuizResult`、`Question`、`AnswerChoice`といったデータを一度にまとめて取得するよう実装しました。
* **ビューの作成**:
    * `app/views/quiz_histories/show.html.erb`を作成し、クイズの概要と各問題の詳細結果を一覧表示するマークアップを実装しました。
* **リンクの追加**:
    * マイページ (`app/views/mypages/show.html.erb`) に、各クイズ履歴の詳細ページへのリンクを追加しました。

### 動作確認
* マイページからクイズ履歴をクリックし、詳細ページに正しく遷移できることを確認。
* 詳細ページに表示される内容が、選択した履歴と一致していることを確認。
* URLを直接編集して他のユーザーの履歴にアクセスしようとすると、`ActiveRecord::RecordNotFound`が発生し、「404 Not Found」ページが表示されることを確認。
* ローカルでの動作確認後、本番環境にデプロイして、正しく動作することを確認。