### PR TITLE
feat: お気に入り登録機能の実装

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,34 @@
+class FavoritesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_question
+
+  def create
+    @favorite = current_user.favorites.build(question: @question)
+    if @favorite.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to @question, notice: 'お気に入りに登録しました。' }
+      end
+    else
+      redirect_to @question, alert: 'お気に入りの登録に失敗しました。'
+    end
+  end
+
+  def destroy
+    @favorite = current_user.favorites.find_by(question: @question)
+    if @favorite&.destroy
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to @question, notice: 'お気に入りを解除しました。' }
+      end
+    else
+      redirect_to @question, alert: 'お気に入りの解除に失敗しました。'
+    end
+  end
+
+  private
+
+  def set_question
+    @question = Question.find(params[:question_id])
+  end
+end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -3,5 +3,6 @@ class MypagesController < ApplicationController
 
   def show
     @quiz_histories = current_user.quiz_histories.order(created_at: :desc)
+    @favorite_questions = current_user.favorite_questions.joins(:favorites).order('favorites.created_at DESC')
   end
 end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :question
+
+  validates :user_id, uniqueness: { scope: :question_id }
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,10 +2,15 @@ class Question < ApplicationRecord
   belongs_to :category
   has_many :answer_choices, dependent: :destroy
   has_many :quiz_results, dependent: :destroy
+  has_many :favorites, dependent: :destroy
 
   accepts_nested_attributes_for :answer_choices
 
   def correct_answer
     answer_choices.find_by(is_correct: true)
+  end
+
+  def favorited_by?(user)
+    favorites.exists?(user: user)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ApplicationRecord
   has_many :quiz_histories, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_questions, through: :favorites, source: :question
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/favorites/_favorite_button.html.erb
+++ b/app/views/favorites/_favorite_button.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag dom_id(question, :favorite_button) do %>
+  <% if question.favorited_by?(current_user) %>
+    <%= button_to question_favorites_path(question), method: :delete, class: "btn btn-warning" do %>
+      <i class="fas fa-star"></i> お気に入り解除
+    <% end %>
+  <% else %>
+    <%= button_to question_favorites_path(question), method: :post, class: "btn btn-outline-warning" do %>
+      <i class="far fa-star"></i> お気に入り登録
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@question, :favorite_button) do %>
+  <%= render 'favorites/favorite_button', question: @question %>
+<% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@question, :favorite_button) do %>
+  <%= render 'favorites/favorite_button', question: @question %>
+<% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,7 +15,7 @@
           <i class="fas fa-search mr-2"></i>
           <span>質問をキーワードで検索</span>
         </a>
-        <a href="#" class="flex items-center justify-center w-full px-4 py-3 text-white bg-[#278B5B] rounded-md hover:bg-opacity-90">
+        <a href="<%= mypage_path %>" class="flex items-center justify-center w-full px-4 py-3 text-white bg-[#278B5B] rounded-md hover:bg-opacity-90">
           <i class="fas fa-star mr-2"></i>
           <span>お気に入りした質問一覧</span>
         </a>

--- a/app/views/mypages/_favorite_questions.html.erb
+++ b/app/views/mypages/_favorite_questions.html.erb
@@ -1,0 +1,17 @@
+<div class="bg-white shadow-md rounded-lg p-6">
+  <h2 class="text-2xl font-bold mb-4">お気に入りした質問</h2>
+  <% if @favorite_questions.any? %>
+    <ul class="divide-y divide-gray-200">
+      <% @favorite_questions.each do |question| %>
+        <li class="py-4 flex justify-between items-center">
+          <%= link_to question.title_en, question_path(question), class: "text-lg hover:text-blue-600 transition duration-300" %>
+          <div class="flex-shrink-0 ml-4">
+            <%= render 'favorites/favorite_button', question: question %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-gray-500">お気に入り登録した質問はまだありません。</p>
+  <% end %>
+</div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -35,4 +35,8 @@
       <p>クイズ履歴がありません。</p>
     </div>
   <% end %>
+
+  <div class="mt-8">
+    <%= render 'mypages/favorite_questions' %>
+  </div>
 </div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -21,6 +21,11 @@
           日本語訳を見る
         </button>
         <p class="text-lg mt-4 hidden" data-qa-card-target="japanese"><%= question.title_jp %></p>
+        <div class="mt-4">
+          <% if user_signed_in? %>
+            <%= render 'favorites/favorite_button', question: question %>
+          <% end %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "home#index"
 
-  resources :questions, only: [:index, :show]
+  resources :questions, only: [:index, :show] do
+    resource :favorites, only: [:create, :destroy]
+  end
 end

--- a/db/migrate/20250906114928_create_favorites.rb
+++ b/db/migrate/20250906114928_create_favorites.rb
@@ -1,0 +1,10 @@
+class CreateFavorites < ActiveRecord::Migration[7.1]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :question, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_11_031445) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_06_114928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_11_031445) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "question_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["question_id"], name: "index_favorites_on_question_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "questions", force: :cascade do |t|
@@ -84,6 +93,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_11_031445) do
   end
 
   add_foreign_key "answer_choices", "questions"
+  add_foreign_key "favorites", "questions"
+  add_foreign_key "favorites", "users"
   add_foreign_key "questions", "categories"
   add_foreign_key "quiz_histories", "categories"
   add_foreign_key "quiz_histories", "users"

--- a/test/controllers/favorites_controller_test.rb
+++ b/test/controllers/favorites_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoritesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/favorites.yml
+++ b/test/fixtures/favorites.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  question: one
+
+two:
+  user: two
+  question: two

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Closes #20

### 概要
ユーザーがクイズの質問をお気に入り登録・解除できる機能を実装しました。また、マイページでお気に入りに登録した質問を一覧表示する機能も追加しました。これらの機能には、ページをリロードせずに状態を更新するTurbo Streamsを使用しています。

### 完了の定義
- Favoriteモデルが生成され、UserモデルとQuestionモデルとの多対多の関連付けが正しく設定されていることを確認しました。
- ログインユーザーがお気に入り登録・解除できることを確認しました。
- 質問一覧ページで、ページリロードなしでお気に入り状態が切り替わることを確認しました。
- マイページに、お気に入り登録した質問の一覧が表示されることを確認しました。
- 同じユーザーが同じ質問を複数回お気に入り登録できないことを確認しました。

### 実装内容
* **Favoriteモデルと関連付け**: `Favorite`モデルを生成し、`User`と`Question`モデルとの関連付けを設定しました。また、一意性を保つためのバリデーションも追加しました。
* **ルーティング**: `config/routes.rb`で、`questions`リソース内に`favorites`の`create`と`destroy`アクションをネストさせました。
* **コントローラーと非同期処理**: `FavoritesController`を作成し、`create`と`destroy`アクションにTurbo Streamsで応答するロジックを実装しました。これにより、ボタンの表示を非同期で更新します。
* **ビュー**: お気に入りボタンを`_favorite_button.html.erb`としてパーシャル化し、`questions/index.html.erb`と`mypages/show.html.erb`から呼び出すことで、再利用性を高めました。
* **マイページ連携**: `MypagesController`に`@favorite_questions`を追加し、マイページでお気に入り質問の一覧が表示されるようにしました。

### 動作確認
* サーバーを起動し、ログイン・非ログイン両方の状態でお気に入りボタンの表示を確認。
* 質問一覧ページでお気に入りボタンを操作し、ページがリロードされずにボタンのアイコンが切り替わることを確認。
* マイページに移動し、お気に入りに登録した質問が正しく一覧表示されることを確認。
* ローカルでの動作確認後、本番環境にデプロイし、正常に動作することを確認。