### PR TITLE
feat: 認証関連UIの改善と機能修正

### DIFF
--- a/app/javascript/controllers/flash_message_controller.js
+++ b/app/javascript/controllers/flash_message_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="flash-message"
+export default class extends Controller {
+  connect() {
+    setTimeout(() => {
+      this.close()
+    }, 3000)
+  }
+
+  close() {
+    this.element.classList.add('opacity-0', 'transition-opacity', 'duration-500')
+    setTimeout(() => {
+      this.element.remove()
+    }, 500)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import FilterController from "./filter_controller"
 application.register("filter", FilterController)
 
+import FlashMessageController from "./flash_message_controller"
+application.register("flash-message", FlashMessageController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.hello', email: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('.someone_requested_password_change') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.change_my_password'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('.ignore_email_if_not_requested') %></p>
+<p><%= t('.password_wont_change_until_new_one_created') %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,38 @@
-<h2>Change your password</h2>
+<div class="flex items-center justify-center">
+  <div class="w-full max-w-md">
+    <div class="bg-white shadow-lg rounded-lg px-8 pt-6 pb-8 mb-4">
+      <h2 class="text-3xl font-extrabold text-center text-gray-900 mb-6">パスワードの再設定</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-6" }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+        <div>
+          <div class="flex items-baseline justify-between">
+            <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700" %>
+            <% if @minimum_password_length %>
+              <em class="text-xs text-gray-500">(<%= @minimum_password_length %>文字以上)</em>
+            <% end %>
+          </div>
+          <div class="mt-1">
+            <%= f.password_field :password, autofocus: true, autocomplete: "new-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <div>
+          <%= f.label :password_confirmation, "新しいパスワード(確認)", class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <div>
+          <%= f.submit "パスワードを変更", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" %>
+        </div>
+      <% end %>
+    </div>
+    <div class="text-center text-sm">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,26 @@
-<h2>Forgot your password?</h2>
+<div class="flex items-center justify-center">
+  <div class="w-full max-w-md">
+    <div class="bg-white shadow-lg rounded-lg px-8 pt-6 pb-8 mb-4">
+      <h2 class="text-3xl font-extrabold text-center text-gray-900 mb-6">パスワードをお忘れですか？</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-6" }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <div>
+          <p class="text-sm text-gray-600 mb-4">ご登録のメールアドレスを入力してください。パスワード再設定のご案内を送信します。</p>
+          <%= f.label :email, class: "block text-sm font-medium text-gray-700 sr-only" %>
+          <div class="mt-1">
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", required: true, placeholder: "メールアドレス", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <div>
+          <%= f.submit "再設定メールを送信", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" %>
+        </div>
+      <% end %>
+    </div>
+    <div class="text-center text-sm">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,70 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="flex items-center justify-center">
+  <div class="w-full max-w-md space-y-8">
+    <div class="bg-white shadow-lg rounded-lg px-8 pt-6 pb-8">
+      <h2 class="text-3xl font-extrabold text-center text-gray-900 mb-6">アカウント編集</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-6" }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <div>
+          <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 text-sm" role="alert">
+            <p>現在、メールアドレスの確認待ちです: <%= resource.unconfirmed_email %></p>
+          </div>
+        <% end %>
+
+        <div>
+          <div class="flex items-baseline justify-between">
+            <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+            <i class="text-xs text-gray-500">(変更しない場合は空欄)</i>
+          </div>
+          <div class="mt-1">
+            <%= f.password_field :password, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+          <% if @minimum_password_length %>
+            <p class="mt-2 text-xs text-gray-500"><%= @minimum_password_length %> 文字以上</p>
+          <% end %>
+        </div>
+
+        <div>
+          <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <hr class="border-t border-gray-200">
+
+        <div>
+          <div class="flex items-baseline justify-between">
+            <%= f.label :current_password, class: "block text-sm font-medium text-gray-700" %>
+            <i class="text-xs text-gray-500">(変更の確認に必須)</i>
+          </div>
+          <div class="mt-1">
+            <%= f.password_field :current_password, autocomplete: "current-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <div>
+          <%= f.submit "更新する", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="bg-white shadow-lg rounded-lg px-8 py-6">
+      <h3 class="text-xl font-bold text-gray-900 mb-4">アカウントの削除</h3>
+      <p class="text-sm text-gray-600 mb-4">アカウントを削除すると元に戻すことはできません。本当によろしいですか？</p>
+      <%= button_to "アカウントを削除する", registration_path(resource_name), data: { confirm: "本当によろしいですか？", turbo_confirm: "本当によろしいですか？" }, method: :delete, class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500" %>
+    </div>
+
+    <div class="text-center text-sm">
+      <%= link_to "戻る", :back, class: "font-medium text-primary hover:opacity-80" %>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,44 @@
-<h2>Sign up</h2>
+<div class="flex items-center justify-center">
+  <div class="w-full max-w-md">
+    <div class="bg-white shadow-lg rounded-lg px-8 pt-6 pb-8 mb-4">
+      <h2 class="text-3xl font-extrabold text-center text-gray-900 mb-6">アカウント作成</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-6" }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <div>
+          <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <div>
+          <div class="flex items-center justify-between">
+            <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+            <% if @minimum_password_length %>
+              <em class="text-xs text-gray-500">(<%= @minimum_password_length %>文字以上)</em>
+            <% end %>
+          </div>
+          <div class="mt-1">
+            <%= f.password_field :password, autocomplete: "new-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <div>
+          <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
+
+        <div>
+          <%= f.submit "アカウントを作成", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" %>
+        </div>
+      <% end %>
+    </div>
+    <div class="text-center text-sm">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,39 @@
-<h2>Log in</h2>
+<div class="flex items-center justify-center">
+  <div class="w-full max-w-md">
+    <div class="bg-white shadow-lg rounded-lg px-8 pt-6 pb-8 mb-4">
+      <h2 class="text-3xl font-extrabold text-center text-gray-900 mb-6">ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6" }) do |f| %>
+        <div>
+          <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+        <div>
+          <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.password_field :password, autocomplete: "current-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm" %>
+          </div>
+        </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+        <% if devise_mapping.rememberable? %>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center">
+              <%= f.check_box :remember_me, class: "h-4 w-4 text-primary focus:ring-primary border-gray-300 rounded" %>
+              <%= f.label :remember_me, class: "ml-2 block text-sm text-gray-900" %>
+            </div>
+          </div>
+        <% end %>
+
+        <div>
+          <%= f.submit "ログイン", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" %>
+        </div>
+      <% end %>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
+    <div class="text-center text-sm">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+    <p class="font-bold">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
-    <ul>
+    </p>
+    <ul class="mt-2 list-disc list-inside">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,27 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+<div class="space-y-1">
+  <%- if controller_name != 'sessions' %>
+    <%= link_to "ログインはこちら", new_session_path(resource_name), class: "font-medium text-primary hover:opacity-80" %><br />
   <% end %>
-<% end %>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= link_to "アカウント作成はこちら", new_registration_path(resource_name), class: "font-medium text-primary hover:opacity-80" %><br />
+  <% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "font-medium text-primary hover:opacity-80" %><br />
+  <% end %>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= link_to "認証メールが届かない場合", new_confirmation_path(resource_name), class: "font-medium text-primary hover:opacity-80" %><br />
+  <% end %>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <%= link_to "アカウントロック解除メールが届かない場合", new_unlock_path(resource_name), class: "font-medium text-primary hover:opacity-80" %><br />
+  <% end %>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= button_to "#{OmniAuth::Utils.camelize(provider)}でログイン", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "font-medium text-primary hover:opacity-80" %><br />
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,0 +1,18 @@
+<% flash.each do |key, message| %>
+  <%
+    color_class = case key
+                  when 'notice'
+                    'bg-green-100 border-green-400 text-green-700'
+                  when 'alert'
+                    'bg-red-100 border-red-400 text-red-700'
+                  else
+                    'bg-gray-100 border-gray-400 text-gray-700'
+                  end
+  %>
+  <div data-controller="flash-message" class="<%= color_class %> border px-4 py-3 rounded relative mb-2" role="alert">
+    <span class="block sm:inline"><%= message %></span>
+    <button data-action="click->flash-message#close" class="absolute top-0 bottom-0 right-0 px-4 py-3">
+      <svg class="fill-current h-6 w-6 text-gray-500" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
+    </button>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,10 +34,8 @@
       </div>
     </header>
 
-    <div id="flash" class="text-center">
-      <% flash.each do |key, value| %>
-        <div class="alert alert-<%= key %>"><%= value %></div>
-      <% end %>
+    <div id="flash-messages" class="fixed top-20 right-4 z-50 w-full max-w-xs">
+      <%= render 'layouts/flash_messages' %>
     </div>
 
     <main class="flex-grow container mx-auto px-4 py-8">

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,63 @@
+ja:
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: "アカウントの有効化について"
+      reset_password_instructions:
+        subject: "パスワード再設定のご案内"
+        hello: "こんにちは、%{email}さん！"
+        someone_requested_password_change: "パスワードの変更リクエストがありました。以下のリンクからパスワードを変更できます。"
+        change_my_password: "パスワードを変更する"
+        ignore_email_if_not_requested: "このリクエストに心当たりがない場合は、このメールを無視してください。"
+        password_wont_change_until_new_one_created: "上記のリンクにアクセスして新しいパスワードを作成するまで、パスワードは変更されません。"
+      unlock_instructions:
+        subject: "アカウントのロック解除について"
+      email_changed:
+        subject: "メールアドレス変更について"
+      password_change:
+        subject: "パスワード変更について"
+    confirmations:
+      confirmed: "アカウントを有効にしました。"
+      send_instructions: "アカウント有効化のメールを送信しました。"
+      send_paranoid_instructions: "ご登録のメールアドレスにアカウント有効化のメールを送信しました。"
+    failure:
+      already_authenticated: "すでにログインしています。"
+      inactive: "アカウントが有効ではありません。"
+      invalid: "メールアドレスまたはパスワードが違います。"
+      locked: "アカウントがロックされています。"
+      last_attempt: "アカウントがロックされます。再度ログインを試す前に、ロック解除のメールを確認してください。"
+      not_found_in_database: "メールアドレスまたはパスワードが違います。"
+      timeout: "セッションの有効期限が切れました。再度ログインしてください。"
+      unauthenticated: "ログインしてください。"
+      unconfirmed: "アカウントが有効ではありません。"
+    passwords:
+      no_token: "パスワード再設定のリンクが無効です。メールアドレスを再確認してください。"
+      send_instructions: "パスワード再設定のメールを送信しました。"
+      send_paranoid_instructions: "ご登録のメールアドレスにパスワード再設定のメールを送信しました。"
+      updated: "パスワードを変更しました。"
+      updated_not_active: "パスワードを変更しました。"
+    registrations:
+      signed_up: "アカウント登録が完了しました。"
+      signed_up_but_inactive: "アカウント登録が完了しました。アカウントが有効ではありません。"
+      signed_up_but_locked: "アカウント登録が完了しました。アカウントがロックされています。"
+      signed_up_but_unconfirmed: "アカウント登録が完了しました。アカウント有効化のメールを送信しました。"
+      update_needs_confirmation: "アカウントを更新しました。メールアドレスの確認が必要です。"
+      updated: "アカウントを更新しました。"
+      destroyed: "アカウントを削除しました。"
+    sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+    unlocks:
+      send_instructions: "アカウントロック解除のメールを送信しました。"
+      send_paranoid_instructions: "ご登録のメールアドレスにアカウントロック解除のメールを送信しました。"
+      unlocked: "アカウントのロックを解除しました。"
+  errors:
+    messages:
+      already_confirmed: "すでに有効化されています。"
+      confirmation_period_expired: "有効期限が切れました。再度リクエストしてください。"
+      expired: "有効期限が切れました。再度リクエストしてください。"
+      not_found: "見つかりませんでした。"
+      not_locked: "ロックされていません。"
+      not_saved:
+        one: "%{resource}を保存できませんでした: 1つのエラーがあります。"
+        other: "%{resource}を保存できませんでした: %{count}つのエラーがあります。"


### PR DESCRIPTION
close #78

### 概要 (Overview)

Issue #78 に基づき、ユーザー認証フロー（サインアップ、ログインなど）のUIを改善しました。また、本PRには実装時に発生した問題とその解決策に関する詳細な振り返りを記載しています。

### 変更点 (Changes)

- **フラッシュメッセージのUI改善**:
  - フラッシュメッセージの表示ロジックを `_flash_messages.html.erb` パーシャルに分離しました。
  - メッセージの種類（成功/警告）に応じて色を適用し、クリックまたは数秒後に自動で非表示になる機能を実装しました。

- **Devise関連ビューのUI改善**:
  - Deviseの各ビュー（サインアップ、ログイン、パスワードリセット等）を、カード風のコンテナで囲い、デザインを統一しました。
  - サイトのプライマリカラーを主要なボタンやリンクに適用しました。

### 実装時の問題と解決策 (Issues and Solutions)

今回の実装では、主に以下の2つの問題に直面しました。

#### 1. フラッシュメッセージが動作しない問題
- **原因**: 新しく作成したStimulusコントローラ (`flash_message_controller.js`) が、アプリケーションに正しく読み込まれていませんでした。
- **解決策**: `app/javascript/controllers/index.js` にて、`flash_message_controller` を正しくインポートし、Stimulusアプリケーションに登録しました。

#### 2. パスワード再設定メールが日本語化されない問題
- **原因**: DeviseのメールテンプレートがI18nヘルパーを使用せずに直接英語で記述されていたため、日本語翻訳が適用されていませんでした。
- **解決策**:
  - メールテンプレート (`app/views/devise/mailer/reset_password_instructions.html.erb`) を修正し、`t()` メソッドを使用して翻訳キーを参照するように変更しました。
  - `config/locales/devise.ja.yml` に対応する日本語翻訳を追加しました。


### 動作確認 (Verification)

- **ローカル環境**: 全ての認証関連ビューでUIが期待通りに表示され、フラッシュメッセージが正しく動作することを確認済。
- **デプロイ後**: 本番環境でも同様に、表示崩れや機能不全が発生していないことを最終確認。